### PR TITLE
Update outdated repository URLs in project URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,14 +37,15 @@ dynamic = ["version"]
 
 [project.urls]
 Documentation = "https://python-secret-type.readthedocs.io"
-Issues = "https://github.com/yasyf/secret-type/issues"
-Source = "https://github.com/yasyf/secret-type"
+Issues = "https://github.com/yasyf/python-secret-type/issues"
+Source = "https://github.com/yasyf/python-secret-type"
 
 [tool.hatch.version]
 path = "secret_type/__about__.py"
 
 [tool.hatch.envs.default]
 dependencies = ["pytest", "pytest-cov"]
+
 [tool.hatch.envs.default.scripts]
 cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=secret_type --cov=tests {args}"
 no-cov = "cov --no-cov {args}"


### PR DESCRIPTION
I stumbled upon the outdated repository URLs on PyPI (and no redirect forwarding to the new ones).

To be fair, just updating them here won't make a difference without a new release published to PyPI, but in case one gets made, the links will work again. (Maybe this alone is even worth a new release.)